### PR TITLE
Refactoring: extract constant.

### DIFF
--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -8,6 +8,9 @@
        :dynamic true}
   *anti-forgery-token*)
 
+(def ^{:doc "Default name of anti-forgery-token's field."}
+  anti-forgery-token-field "__anti-forgery-token")
+
 (defn- new-token []
   (random/base64 60))
 
@@ -27,7 +30,7 @@
          (:multipart-params request)))
 
 (defn- default-request-token [request]
-  (or (-> request form-params (get "__anti-forgery-token"))
+  (or (-> request form-params (get anti-forgery-token-field))
       (-> request :headers (get "x-csrf-token"))
       (-> request :headers (get "x-xsrf-token"))))
 

--- a/src/ring/util/anti_forgery.clj
+++ b/src/ring/util/anti_forgery.clj
@@ -8,4 +8,4 @@
   This ensures that the form it's inside won't be stopped by the anti-forgery
   middleware."
   []
-  (html (hidden-field "__anti-forgery-token" *anti-forgery-token*)))
+  (html (hidden-field anti-forgery-token-field *anti-forgery-token*)))


### PR DESCRIPTION
Allows not to hardcode field name when this middleware is used.
