### PR TITLE
Fix valid-request? function

### DIFF
--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -48,8 +48,8 @@
       (= method :options)))
 
 (defn- valid-request? [request read-token]
-  (and (not (get-request? request))
-       (not (valid-token? request read-token))))
+  (or (get-request? request)
+      (valid-token? request read-token)))
 
 (def ^:private default-error-response
   {:status  403
@@ -99,11 +99,11 @@
         (let [token (find-or-create-token request)]
           (binding [*anti-forgery-token* token]
             (if (valid-request? request read-token)
-              (error-handler request)
-              (add-session-token (handler request) request token)))))
+              (add-session-token (handler request) request token)
+              (error-handler request)))))
        ([request respond raise]
         (let [token (find-or-create-token request)]
           (binding [*anti-forgery-token* token]
             (if (valid-request? request read-token)
-              (error-handler request respond raise)
-              (handler request #(respond (add-session-token % request token)) raise)))))))))
+              (handler request #(respond (add-session-token % request token)) raise)
+              (error-handler request respond raise)))))))))


### PR DESCRIPTION
I was confused when I was reading the source for valid-request?. Eventually I realised that it returns false for a valid request and true for an invalid request.

- Now returns true if a request is valid, instead of false. Because this
is a private var this should be safe.
- Simplify the boolean expressions to an `(or` instead of `(and (not`

The other approach would be to rename this function to `invalid-request?` and then the function name would match the implementation and there would be no risk of breakage if people were using this private function. I took a look at crossclj and couldn't [see anything](https://crossclj.info/fun/ring.middleware.anti-forgery/valid-request%3F.html) public.