### PR TITLE
Should anti-forgery token be kept after valid POST?

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ You should therefore only apply this middleware to the parts of your
 application designed to be accessed through a web browser. This
 middleware should not be applied to handlers that define web services.
 
+Furthermore, if you use the session strategy, you must be aware of a gotcha
+associated with all ring session apps. You almost never want to write a handler
+that looks like this:
+
+```clojure
+(defn handler [req]
+  {:status 200
+   :headers {}
+   :body "ok"
+   :session {"foo" "bar"}})
+```
+
+This handler will remove the anti-forgery token from the response, meaning
+future requests will fail the anti-forgery check and receive a 403. Instead, you
+must copy the session from the request:
+
+```clojure
+(defn handler [req]
+  {:status 200
+   :headers {}
+   :body "ok"
+   :session (assoc (:session req) "foo" "bar")})
+```
+
 ## License
 
 Copyright © 2018 James Reeves

--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -105,6 +105,20 @@
     (is (contains? session ::af/anti-forgery-token))
     (is (= (session "foo") "bar"))))
 
+(deftest session-in-response-does-not-destroy-token-test
+  (let [handler    (wrap-anti-forgery (fn [req]
+                                        {:status  200
+                                         :headers {}
+                                         :session {"resp" "foo"}
+                                         :body    nil}))
+        valid-post (-> (mock/request :post "/")
+                       (assoc :session {"req"                   "foo"
+                                        ::af/anti-forgery-token "foo"})
+                       (assoc :headers {"x-csrf-token" "foo"}))]
+    (is (= (:session (handler valid-post))
+           {::af/anti-forgery-token "foo"
+            "resp"                  "foo"}))))
+
 (deftest custom-error-response-test
   (let [response   {:status 200, :headers {}, :body "Foo"}
         error-resp {:status 500, :headers {}, :body "Bar"}

--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -105,20 +105,6 @@
     (is (contains? session ::af/anti-forgery-token))
     (is (= (session "foo") "bar"))))
 
-(deftest session-in-response-does-not-destroy-token-test
-  (let [handler    (wrap-anti-forgery (fn [req]
-                                        {:status  200
-                                         :headers {}
-                                         :session {"resp" "foo"}
-                                         :body    nil}))
-        valid-post (-> (mock/request :post "/")
-                       (assoc :session {"req"                   "foo"
-                                        ::af/anti-forgery-token "foo"})
-                       (assoc :headers {"x-csrf-token" "foo"}))]
-    (is (= (:session (handler valid-post))
-           {::af/anti-forgery-token "foo"
-            "resp"                  "foo"}))))
-
 (deftest custom-error-response-test
   (let [response   {:status 200, :headers {}, :body "Foo"}
         error-resp {:status 500, :headers {}, :body "Bar"}


### PR DESCRIPTION
My question is... is the test in this diff properly or improperly failing?

Actual
=====

This test fails. The response session is `{"resp" "foo"}` and is missing `::af/anti-forgery-token`. The makes the following sequence inevitable:

1. receive a POST, with valid anti-forgery tokens (in the session and the headers/form params)
2. respond with session data (perhaps the user logged in, and you are storing their identity in the session)
3. forget to copy `::af/anti-forgery-token` from the request session to the response session
4. the next POST cannot possibly be valid, because it will not have `::af/anti-forgery-token` in the session

I can think of two ways to make the test pass:

Solution 1
=======

The "ring-session way". Require that the inner-most handler copy `::af/anti-forgery-token` from the request into the response session. There are two ways to do this, both of which have downsides.

* Copy the entire request session into the response before assoc-ing our new session data. This would copy `::af/anti-forgery-token`, but of course would also copy any other keys. In the case of our test, this means the response session would also contain `{"req" "foo"}`, which may or may not be harmless, depending on the application.
* Or, explicitly copy only `::af/anti-forgery-token` from the request to the response session. This feels like it leaks knowledge about ring-anti-forgery into inner layers of the middleware stack.

I think that the first method of copying is what this library expects. However, that means that almost all examples in the wild of using ring-session are wrong, at least when ring-anti-forgery is also enabled. Instead of writing handlers that just set the session, you should almost always do what [this library](https://github.com/ring-clojure/ring-anti-forgery/blob/092cbaa4a95d2da3d5ff925198edac92fb8b7055/src/ring/middleware/anti_forgery/session.clj#L24-L28) and [other similar libraries](https://github.com/cemerick/friend/blob/12c5b6636430edec52c27d3f95c1ed9c6e7a1dd4/src/cemerick/friend.clj#L83-L84) do.

If this is so, I suggest documenting it in the README, with an example of what the handler should do.

Solution 2
=======

Have `ring-anti-forgery` copy the token from the request to the response. This is not the "ring-session way", but is there any downside? I suppose it means that inner layers of the middleware stack can't modify or remove the anti-forgery token. But isn't that OK, or even desirable?

In the end, whether the answer is Solution 1 or Solution 2, I'd be happy to provide patches to improve the documentation or change the code.