### PR TITLE
Makes the anti-forgery token available to handlers from the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ pattern, which requires the session middleware to be in place:
 ```
 
 The token will be used to validate the request is accessible via the
-`*anti-forgery-token*` var.
+`*anti-forgery-token*` var. The token is also placed in the request
+under the `:anti-forgery-token` key.
 
 ### Custom token reader
 

--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -54,7 +54,10 @@
 
   The anti-forgery token can be placed into a HTML page via the
   *anti-forgery-token* var, which is bound to a (possibly deferred) token.
-  By default, the token is expected to be in a form field named
+  The token is also available in the request under
+  `:anti-forgery-token`.
+
+  By default, the token is expected to be POSTed in a form field named
   '__anti-forgery-token', or in the 'X-CSRF-Token' or 'X-XSRF-Token'
   headers.
 
@@ -88,14 +91,14 @@
         (if (valid-request? strategy request read-token)
           (let [token (strategy/get-token strategy request)]
             (binding [*anti-forgery-token* token]
-              (when-let [response (handler request)]
+              (when-let [response (handler (assoc request :anti-forgery-token token))]
                 (strategy/write-token strategy request response token))))
           (error-handler request)))
        ([request respond raise]
         (if (valid-request? strategy request read-token)
           (let [token (strategy/get-token strategy request)]
             (binding [*anti-forgery-token* token]
-              (handler request
+              (handler (assoc request :anti-forgery-token token)
                        #(respond
                          (when %
                            (strategy/write-token strategy request % token)))

--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -68,6 +68,21 @@
       (is (= (get-in response [:session ::af/anti-forgery-token])
              (:body response))))))
 
+(deftest token-in-request-test
+ (letfn [(handler
+           ([request] {:status 200 :headers {} :body (:anti-forgery-token request)})
+           ([request respond _] (respond (handler request))))]
+   (let [app      (wrap-anti-forgery handler)
+         response (app (mock/request :get "/"))]
+     (is (= (get-in response [:session ::af/anti-forgery-token])
+            (:body response))))
+   (let [app   (wrap-anti-forgery handler)
+         resp  (promise)
+         error (promise)]
+     (app (mock/request :get "/") resp error)
+     (is (= (get-in @resp [:session ::af/anti-forgery-token])
+            (:body @resp))))))
+
 (deftest nil-response-test
   (letfn [(handler [request] nil)]
     (let [response ((wrap-anti-forgery handler) (mock/request :get "/"))]


### PR DESCRIPTION
See discussion here: https://github.com/ring-clojure/ring-defaults/issues/23