### PR TITLE
Extract hiccup from anti-forgery-field

### DIFF
--- a/src/ring/util/anti_forgery.clj
+++ b/src/ring/util/anti_forgery.clj
@@ -4,9 +4,14 @@
             [hiccup.form :refer [hidden-field]]
             [ring.middleware.anti-forgery :refer [*anti-forgery-token*]]))
 
+(defn anti-forgery-field-hiccup
+  "The hiccup used to generate the result of anti-forgery-field."
+  []
+  (hidden-field "__anti-forgery-token" (force *anti-forgery-token*)))
+
 (defn anti-forgery-field
   "Create a hidden field with the session anti-forgery token as its value.
   This ensures that the form it's inside won't be stopped by the anti-forgery
   middleware."
   []
-  (html (hidden-field "__anti-forgery-token" (force *anti-forgery-token*))))
+  (html (anti-forgery-field-hiccup)))


### PR DESCRIPTION
I have some logic that handles hiccup better than straight html, and
would like my anti forgery field in that form as well. Rather than
replicate what's already being done in this library, I thought others
would find the additional function useful as well.