### PR TITLE
Update minimum Clojure version and dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/ring-clojure/ring-anti-forgery"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [crypto-random "1.2.0"]
                  [crypto-equality "1.0.0"]
                  [hiccup "1.0.5"]]
@@ -12,10 +12,10 @@
   {:output-path "codox"
    :project     {:name "Ring Anti-Forgery"}
    :source-uri  "http://github.com/ring-clojure/ring-anti-forgery/blob/{version}/{filepath}#L{line}"}
-  :aliases {"test-all" ["with-profile" "default:+1.6:+1.7:+1.8:+1.9" "test"]}
+  :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10:+1.11" "test"]}
   :profiles
-  {:dev {:dependencies [[ring/ring-mock "0.3.2"]]}
-   :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-   :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-   :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-   :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}})
+  {:dev  {:dependencies [[ring/ring-mock "0.3.2"]]}
+   :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
+   :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
+   :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+   :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}})

--- a/project.clj
+++ b/project.clj
@@ -4,17 +4,17 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [crypto-random "1.2.0"]
-                 [crypto-equality "1.0.0"]
+                 [crypto-random "1.2.1"]
+                 [crypto-equality "1.0.1"]
                  [hiccup "1.0.5"]]
-  :plugins [[lein-codox "0.10.3"]]
+  :plugins [[lein-codox "0.10.8"]]
   :codox
   {:output-path "codox"
    :project     {:name "Ring Anti-Forgery"}
    :source-uri  "http://github.com/ring-clojure/ring-anti-forgery/blob/{version}/{filepath}#L{line}"}
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10:+1.11" "test"]}
   :profiles
-  {:dev  {:dependencies [[ring/ring-mock "0.3.2"]]}
+  {:dev  {:dependencies [[ring/ring-mock "0.4.0"]]}
    :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}


### PR DESCRIPTION
There are two changes made by this PR:
- Bump minimum Clojure version from 1.5.1 to 1.7.0. This follows the same policy as the rest of the Ring libraries.
- Bump all dependencies and plugins. Tests succeed and the update to the `crypto-random` dependency ensures that e.g. `metosin/malli` and `ring-anti-forgery` can be used without dependency conflicts (as the former depends on version 1.2.1).