### PR TITLE
Removes dependecy of apache-commons to enable babashka users to use ring-anti-forgery

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
+        crypto-equality/crypto-equality {:mvn/version "1.0.1"}
+        hiccup/hiccup {:mvn/version "1.0.5"}}}

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,6 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [crypto-random "1.2.1"]
                  [crypto-equality "1.0.1"]
                  [hiccup "1.0.5"]]
   :plugins [[lein-codox "0.10.8"]]

--- a/src/ring/middleware/anti_forgery/session.clj
+++ b/src/ring/middleware/anti_forgery/session.clj
@@ -1,8 +1,14 @@
 (ns ring.middleware.anti-forgery.session
   "Contains the synchronizer token (or session) strategy."
   (:require [ring.middleware.anti-forgery.strategy :as strategy]
-            [crypto.equality :as crypto]
-            [crypto.random :as random]))
+            [crypto.equality :as crypto]))
+
+(defn- random-base64 [buffer-size]
+  (let [random (java.security.SecureRandom.)
+        base64 (.withoutPadding (java.util.Base64/getUrlEncoder))
+        buffer (byte-array buffer-size)]
+    (.nextBytes random buffer)
+    (.encodeToString base64 buffer)))
 
 (defn- session-token [request]
   (get-in request [:session :ring.middleware.anti-forgery/anti-forgery-token]))
@@ -11,7 +17,7 @@
   strategy/Strategy
   (get-token [this request]
     (or (session-token request)
-        (random/base64 60)))
+        (random-base64 60)))
 
   (valid-token? [_ request token]
     (when-let [stored-token (session-token request)]


### PR DESCRIPTION
The merge request removes a library with apache-commons dependency and replaces the functionality with plain Java functions. This is needed to get ring-anti-forgery to work with babashka.

Would be nice if you would consider my pull request.